### PR TITLE
Add web server to ESP Web Tools configs

### DIFF
--- a/esp-web-tools/esp32.yaml
+++ b/esp-web-tools/esp32.yaml
@@ -38,3 +38,6 @@ dashboard_import:
 # to provision wifi credentials to the device.
 esp32_improv:
   authorizer: none
+
+# To have a "next url" for improv serial
+web_server:

--- a/esp-web-tools/esp8266.yaml
+++ b/esp-web-tools/esp8266.yaml
@@ -33,3 +33,6 @@ captive_portal:
 
 dashboard_import:
   package_import_url: github://esphome/example-configs/esp-web-tools/esp8266.yaml@v1
+
+# To have a "next url" for improv serial
+web_server:


### PR DESCRIPTION
This allows it to be picked up as "NEXT URL" for Improv Serial and unlocking that option in ESP Web Tools.