### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
           - esp32
     steps:
       - uses: actions/checkout@v3.0.0
-      - uses: esphome/build-action@v1.5.0
+      - uses: esphome/build-action@v1.5.2
         id: esphome-build
         with:
           yaml_file: ${{ matrix.firmware }}/${{ matrix.chip }}.yaml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,10 @@ jobs:
         id: esphome-build
         with:
           yaml_file: ${{ matrix.firmware }}/${{ matrix.chip }}.yaml
-      - uses: actions/upload-artifact@v3.0.0
+      - run: |
+          mkdir output
+          mv "${{ steps.esphome-build.outputs.name }}" output/
+      - uses: actions/upload-artifact@v3.1.1
         with:
           name: ${{ matrix.firmware }}-${{ matrix.chip }}
-          path: ${{ steps.esphome-build.outputs.name }}
+          path: output


### PR DESCRIPTION
Looks like the bump of ESPHome action builder in 018f057 broke the build. This fixes it by syncing it with https://github.com/esphome/workflows/blob/main/.github/workflows/publish.yml#L53